### PR TITLE
Make user-add.py Python 3 compatible & replace "NO-BREAK SPACE" by a normal space

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,6 +4,6 @@
 DB_PATH = '/tmp/openvpn-auth-test.sqlite'
 # Minimum required length for passwords when creating users
 PASSWORD_LENGTH_MIN = 8
-# Hash algorithm to use for passwords storage. Can be one of:
+# Hash algorithm to use for passwords storage. Can be one of:
 # md5, sha1, sha224, sha256, sha384, sha512
 HASH_ALGORITHM = 'sha256'

--- a/user-add.py
+++ b/user-add.py
@@ -34,7 +34,7 @@ while not password_ok:
     else:
         print("ERROR: passwords don't match")
 
-password = hash_func(password).hexdigest()
+password = hash_func(password.encode("UTF-8")).hexdigest()
 
 db = sqlite3.connect(DB_PATH)
 cursor = db.cursor()


### PR DESCRIPTION
Avoid "TypeError: Unicode-objects must be encoded before hashing".
Tested with Python 3.4.3 & Python 2.7.10.
